### PR TITLE
Fix name of `getHashAsync` function

### DIFF
--- a/android/src/main/cpp/JSIContacts.cpp
+++ b/android/src/main/cpp/JSIContacts.cpp
@@ -22,7 +22,7 @@ namespace mrousavy {
         }
         if (name == "getHashAsync") {
             return jsi::Function::createFromHostFunction(runtime,
-                                                         jsi::PropNameID::forAscii(runtime, "getContactsAsync"),
+                                                         jsi::PropNameID::forAscii(runtime, "getHashAsync"),
                                                          0,
                                                          [this](jsi::Runtime& runtime,
                                                                 const jsi::Value&,


### PR DESCRIPTION
I **think** this should be `getHashAsync`, not `getContactsAsync`, seems like a transcription error?